### PR TITLE
[Feat] game runs asynchronously, user status change immediately

### DIFF
--- a/src/feature/api/game/application/game.service.ts
+++ b/src/feature/api/game/application/game.service.ts
@@ -39,7 +39,7 @@ export class GameService {
     return true;
   }
 
-  getMyMatchId(
+  getMyMatchIdBySocket(
     gameStates: Map<string, GameState>,
     socketId: string,
   ): string | null {
@@ -49,6 +49,13 @@ export class GameService {
         match.playerB.socketId === socketId
       )
         return matchId;
+    }
+    return null;
+  }
+
+  getMyMatchId(gameStates: Map<string, GameState>, id: string): string | null {
+    for (const [matchId, match] of gameStates) {
+      if (match.playerA.id === id || match.playerB.id === id) return matchId;
     }
     return null;
   }

--- a/src/feature/api/game/game.module.ts
+++ b/src/feature/api/game/game.module.ts
@@ -1,4 +1,5 @@
 import { AuthModule } from '../auth/auth.module';
+import { NotificationModule } from '../notification/notification.module';
 import { UsersModule } from '../users/users.module';
 import { GameWithPlayerUseCase } from './application/game-with-player.use-case';
 import { GameService } from './application/game.service';
@@ -21,6 +22,7 @@ import { Module, forwardRef } from '@nestjs/common';
     MikroOrmModule.forFeature([GameEntity, PlayerScoreEntity]),
     forwardRef(() => UsersModule),
     forwardRef(() => AuthModule),
+    NotificationModule,
   ],
   providers: [
     GameService,

--- a/src/feature/api/game/presentation/game.gateway.ts
+++ b/src/feature/api/game/presentation/game.gateway.ts
@@ -75,6 +75,10 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
         client.disconnect();
         return;
       }
+      if (this.gameService.getMyMatchId(this.gameStates, client.id) === null) {
+        client.disconnect();
+        return;
+      }
       await this.userUseCase.updateStatus(user.intraId, 'in-game');
       this.server.emit('changeStatus');
     }

--- a/src/feature/api/game/presentation/game.gateway.ts
+++ b/src/feature/api/game/presentation/game.gateway.ts
@@ -87,8 +87,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       getIntraIdFromSocket(client),
     );
     if (!user) return;
-    await this.userUseCase.updateStatus(user.intraId, 'on-line');
-    this.server.emit('changeStatus');
+
     await this.joinMutex.runExclusive(async () => {
       const matchId = this.gameService.getMyMatchId(this.gameStates, client.id);
       if (!matchId) return;
@@ -112,6 +111,8 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
           playerBScore: match.score.playerB,
           isLadder: match.gameMode === GAME_MODE.normal ? false : true,
         });
+        await this.userUseCase.updateStatus(user.intraId, 'on-line');
+        this.server.emit('changeStatus');
 
         if (match.resetTimeout !== null) clearTimeout(match.resetTimeout);
         this.gameStates.delete(matchId);

--- a/src/feature/api/notification/presentation/notification.gateway.ts
+++ b/src/feature/api/notification/presentation/notification.gateway.ts
@@ -96,7 +96,7 @@ export class NotificationGateway
     //TODO: 두명이 연속으로 접속하는 경우 에러 처리
     if (this.sockets.has(user.id)) return;
     this.sockets.set(user.id, socket.id);
-    await this.userUseCase.updateStatus(user.intraId, 'on-line');
+    await this.userUseCase.updateStatusByIntraId(user.intraId, 'on-line');
     this.server.emit('changeStatus');
   }
 
@@ -110,9 +110,7 @@ export class NotificationGateway
       getIntraIdFromSocket(socket),
     );
     if (!user) return;
-    if (socket.id != this.sockets.get(user.id))
-      return ;
-    await this.userUseCase.updateStatus(user.intraId, 'off-line');
+    if (socket.id != this.sockets.get(user.id)) return;
     this.handleLadderGameCancel(socket);
     await this.normalQueueMutex.runExclusive(() => {
       for (const [matchId, match] of this.normalMatchQueue) {
@@ -131,7 +129,7 @@ export class NotificationGateway
       }
     });
     this.sockets.delete(user.id);
-    await this.userUseCase.updateStatus(user.intraId, 'off-line');
+    await this.userUseCase.updateStatusByIntraId(user.intraId, 'off-line');
     this.server.emit('changeStatus');
   }
 
@@ -142,6 +140,10 @@ export class NotificationGateway
         server_secret_key: process.env.SERVER_SECRET_KEY,
       },
     });
+  }
+
+  getSocketById(id: string): string {
+    return this.sockets.get(id);
   }
 
   @UseGuards(JwtSocketGuard)

--- a/src/feature/api/notification/presentation/notification.gateway.ts
+++ b/src/feature/api/notification/presentation/notification.gateway.ts
@@ -430,6 +430,10 @@ export class NotificationGateway
     this.server.to(socketId).emit('changeStatus');
   }
 
+  handleSocialUpdateToServer() {
+    this.server.emit('changeStatus');
+  }
+
   handleNewFriendRequest(userId: string) {
     const socketId = this.sockets.get(userId);
     this.server.to(socketId).emit('newFriendRequest');

--- a/src/feature/api/users/application/use-case/users.use-case.ts
+++ b/src/feature/api/users/application/use-case/users.use-case.ts
@@ -41,8 +41,12 @@ export class UsersUseCase {
     return await this.repository.findOneByIntraId(intraId);
   }
 
-  async updateStatus(intraId: string, status: string): Promise<User> {
-    return await this.repository.updateStatus(intraId, status);
+  async updateStatusByIntraId(intraId: string, status: string): Promise<User> {
+    return await this.repository.updateStatusByIntraId(intraId, status);
+  }
+
+  async updateStatusById(intraId: string, status: string): Promise<User> {
+    return await this.repository.updateStatusById(intraId, status);
   }
 
   async updateTierAndExp(id: string, exp: number): Promise<User> {

--- a/src/feature/api/users/domain/user.repository.ts
+++ b/src/feature/api/users/domain/user.repository.ts
@@ -10,7 +10,8 @@ export interface UserRepository {
   findOneByName(name: string): Promise<User>;
   findOneByIntraId(intraId: string): Promise<User>;
   updateOne(intraId: string, updateUserDto: UpdateUserDto): Promise<User>;
-  updateStatus(intraId: string, status: string): Promise<User>;
+  updateStatusByIntraId(intraId: string, status: string): Promise<User>;
+  updateStatusById(id: string, status: string): Promise<User>;
   updateTierAndExp(id: string, tier: TIER, exp: number): Promise<User>;
   createOne(createUserDto: CreateUserDto): Promise<User>;
   updateTwoFactorAuth(

--- a/src/feature/api/users/infrastructure/user.repository.impl.ts
+++ b/src/feature/api/users/infrastructure/user.repository.impl.ts
@@ -89,9 +89,20 @@ export class UserRepositoryImpl implements UserRepository {
     return this.toDomain(user);
   }
 
-  async updateStatus(intraId: string, status: string): Promise<User> {
+  async updateStatusByIntraId(intraId: string, status: string): Promise<User> {
     const user = await this.userRepository.findOne({
       intraId,
+      isDeleted: false,
+    });
+    if (!user) return;
+    user.currentStatus = status;
+    await this.userRepository.getEntityManager().flush();
+    return this.toDomain(user);
+  }
+
+  async updateStatusById(id: string, status: string): Promise<User> {
+    const user = await this.userRepository.findOne({
+      id,
       isDeleted: false,
     });
     if (!user) return;


### PR DESCRIPTION
## ✅ 풀\_리퀘스트 체크리스트

<!--
하나씩 확인 후 체크박스에 표시해주세요.
-->

- [x] PR 제목: [Feature/Fix/Refactor...] 작업 내용 한 줄 요약 (브랜치 이름) #이슈번호
- [x] commit message 가 적절한지 확인해주세요.
- [x] 적절한 branch 로 요청했는지 확인해주세요.
- [x] Assignees, Label 을 붙여주세요.
- [x] 주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 Reviewer 로 등록해주세요.
- [x] PR이 승인된 경우 해당 브랜치는 삭제해 주세요!

<br/>

## 🔄 변경 사항

<!-- 해당 pr에서 작업한 내역을 적어주세요. 처음엔 간단하게 요약, list 형식으로 세부사항 작성 -->

원활한 게임을 위해 변경 진행했습니다.
- 기존 for 문으로 match를 순회하던 것을 asynchronous하게 각 매치 마다 interval이 존재하도록 했습니다.
- 소켓이 끊길 때, 매치가 존재해야만 currentStatus를 on-line으로 바꿉니다.
- 게임에 내가 있는 매치가 있을 시에만 게임 소켓에 connect합니다.
- 상태 변경 시 즉시 notification socket으로 emit합니다.

<br/>

## 📎 변경한 이유

- 렉 없이 원활한 게임 및 더블탭 방지!

<br/>

<!-- 관련되어있는 Issue Number 를 작성하세요! 해당 이슈를 이곳에 적으면 pr merge 이후 해당 이슈는 자동으로 close 됩니다. -->


## 👨🏻‍💻 테스트 체크리스트

<!-- 테스트 사항이 있다면 작성해 주세요! -->

- 4개 켜놓고 게임 했을 때 잘 되었습니다.
- 정상 종료, 기권패, 더블탭 등등에서 잘 진행됩니다.

<br/>

## 📌 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 있다면 적어주세요.
주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 리뷰어로 등록해주세요. (다른 사람이 작성한 코드 수정 등)
코드 리뷰 시 더 꼼꼼하게 확인 받고 싶은 부분이 있다면 적어주세요.
-->

<br/>
